### PR TITLE
Matomo PageTracker & Consent Management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12633,6 +12633,11 @@
         }
       }
     },
+    "vue-matomo": {
+      "version": "3.13.5-0",
+      "resolved": "https://registry.npmjs.org/vue-matomo/-/vue-matomo-3.13.5-0.tgz",
+      "integrity": "sha512-mxOKX3tVVP4y3u1kzH6GdsW5J0He5PeijSGLZkfLpdKAmrsXRhdLzl7IewyfvRYAB1LTLl92q+u7gUT9tQTrAw=="
+    },
     "vue-router": {
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.1.6.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "vue-doc-preview": "^0.3.2",
     "vue-i18n": "^8.17.3",
     "vue-json-pretty": "^1.6.3",
+    "vue-matomo": "^3.13.5-0",
     "vue-router": "^3.1.6",
     "vue-rx": "^6.2.0",
     "vue-shortkey": "^3.1.7",

--- a/src/App.vue
+++ b/src/App.vue
@@ -41,7 +41,11 @@ export default {
     name: "App",
     components: { ConfirmDialog },
     computed: {
+        hasConsent() {
+            return this.getSetting("user_eula");
+        },
         ...mapGetters("settings", [
+            "getSetting",
             "getCurrentLocale",
             "isDarkTheme"
         ])
@@ -53,6 +57,14 @@ export default {
         isDarkTheme: {
             handler() {
                 this.$vuetify.theme.dark =  this.isDarkTheme;
+            },
+            immediate: true
+        },
+        hasConsent: {
+            handler(val) {
+                if (val && this.$matomo) {
+                    this.$matomo.rememberConsentGiven();
+                }
             },
             immediate: true
         }

--- a/src/main.js
+++ b/src/main.js
@@ -17,6 +17,7 @@ import i18n from "@/i18n";
 
 // Vue Plugins
 import VueRx from "vue-rx";
+import VueMatomo from "vue-matomo";
 import VueAuth from "@/plugins/auth";
 import VueSecurity from "@/plugins/security";
 import VueNotify from "@/plugins/notify";
@@ -50,6 +51,18 @@ Vue.use(VueAuth, Auth.instance);
 Vue.use(VueSecurity, Security.instance);
 Vue.use(VueNotify, NotifyService.instance);
 Vue.use(VueConfirm, ConfirmService.instance);
+
+Vue.use(VueMatomo, {
+    host: "https://statistik.tekom.de",
+    siteId: 13,
+    trackerFileName: "matomo",
+    router: Auth.router,
+    enableLinkTracking: true,
+    requireConsent: true,
+    trackInitialView: true,
+    disableCookies: false,
+    cookieDomain: "*.iirds.tekom.de"
+});
 
 if (!!+process.env.VUE_APP_LOG_VERSION) {
     // eslint-disable-next-line no-console

--- a/src/toolkit/layout/OtkMenuMore.vue
+++ b/src/toolkit/layout/OtkMenuMore.vue
@@ -198,6 +198,7 @@ export default {
                 this.$t("Actions.restoreSettings"),
                 this.$t("Actions.restoreSettingsInfo"))) {
                 this.setCurrentProgressLocal(1);
+                this.$matomo.forgetConsentGiven();
                 this.resetSettings(true);
                 this.$notify.send(this.$t("Otk.settingsRestored"), "success", 2);
             }


### PR DESCRIPTION
:rocket: **Anpassungen**

- Matomo in Vue integriert
- Consent mit Einstellung gekoppelt

:construction: **Offene Punkte**

- [ ] FirstImpression Tagging / Platzierung Cookie OK?

