### PR TITLE
[BUG] Undefinierter Objekttyp-Filter (Objekte hinzufügen)

### DIFF
--- a/src/config/settings/base.json
+++ b/src/config/settings/base.json
@@ -3,7 +3,6 @@
     "ui_shortcuts": true,
     "ui_assign_preview": true,
     "ui_assign_filter": null,
-    "ui_addobjects_filter": null,
     "ui_addobjects_columns": [
         "name",
         "sourcetype",

--- a/src/store/storage/standalone.js
+++ b/src/store/storage/standalone.js
@@ -50,10 +50,12 @@ const getters = {
     indizesCurrentByType: (state, getters) => {
         return getters.getCurrentObjectUuids.reduce((map, uuid) => {
             let type = getters.typeByUuid[uuid];
-            if (!map.hasOwnProperty(type)) {
-                map[type] = [];
+            if (type) {
+                if (!map.hasOwnProperty(type)) {
+                    map[type] = [];
+                }
+                map[type].push(getters.indexByUuid[uuid]);
             }
-            map[type].push(getters.indexByUuid[uuid]);
             return map;
         }, {});
     },
@@ -169,7 +171,7 @@ const getters = {
     },
     getCurrentObjectTypes: (state, getters) => {
         return Object.entries(getters.indizesCurrentByType).reduce((obj,[k, v]) => {
-            obj[k] = v.length;
+            if (k) obj[k] = v.length;
             return obj;
         }, {});
     },

--- a/src/toolkit/step/OtkStepAddObjects.vue
+++ b/src/toolkit/step/OtkStepAddObjects.vue
@@ -71,14 +71,15 @@
                 <v-autocomplete
                   v-show="!!items.length"
                   ref="type"
-                  :value="getSetting('ui_addobjects_filter')"
+                  :value="filter"
                   :items="getObjectTypeFilterValues"
                   :label="$t('Objects.all')"
+                  :multiple="false"
                   prepend-icon="mdi-filter"
                   single-line
                   hide-details
                   clearable
-                  @change="setLocalSetting({key: 'ui_addobjects_filter', value: $event})"
+                  @change="(v) => filter = v"
                 >
                   <template v-slot:item="{ item }">
                     <span>{{ item.text }} </span>
@@ -341,6 +342,7 @@ export default {
         return {
             loading: false,
             search: null,
+            filter: undefined,
             selected:  [],
             processing: [],
             showHelp: true,
@@ -365,8 +367,7 @@ export default {
     },
     computed: {
         getCurrentObjects() {
-            let filter = this.getSetting("ui_addobjects_filter");
-            return this.getCurrentObjectsByType(filter);
+            return this.getCurrentObjectsByType(this.filter);
         },
         getObjectTypeFilterValues() {
             return Object.entries(this.getCurrentObjectTypes).map(([key, value]) => {
@@ -458,6 +459,14 @@ export default {
         ...mapGetters("properties", [
             "getPropertyLabelById"
         ])
+    },
+    watch: {
+        getCurrentObjects() {
+        // make sure that a set filter doesn't show an empty object list
+            if (this.getCurrentObjects.length === 0 && this.filter) {
+                this.filter = undefined;
+            }
+        }
     },
     methods: {
         ...util,


### PR DESCRIPTION
🚀  **Anpassungen**

- Bugfix undefinierter Objektfilter (`undefined `in Liste)
- Keine Objektfilter mehr in Nutzereinstellungen
- Automatisches Zurücksetzen des Filters, wenn Objektliste sonst leer wäre

🔨  **Offene Punkte**

- [ ] Objekttyp-Filter in "Metadaten vergeben"